### PR TITLE
Prevent autostart of test service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
         max-size: "100m"
         max-file: "5"
   streamlink-test:
+    profiles: ["testing"]
     image: ghcr.io/56k-modem/streamlink:latest
     container_name: streamlink-test
     command: ["/bin/bash","./streamlinkcmd-test.sh"]


### PR DESCRIPTION
Exclude `streamlink-test` from the default Compose startup by moving it behind a manual profile.
`docker compose up -d` now starts only the normal recorder and support services, while the test
container remains available via an explicit `--profile testing` invocation.

Operational impact is limited to local workflow: anyone who wants the test container must
start it intentionally, for example with `docker compose --profile testing up streamlink-test`.