### PR TITLE
Switch to BtbN ffmpeg builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,13 @@ FROM python:3.12.7-slim-bookworm
 ENV streamlinkCommit=d3828a5e7b7025856d800c231b222ea64004dc37
 RUN groupadd -g 1000 csd && useradd -m -u 1000 -g csd csd && \
     apt-get update && apt-get install -y --no-install-recommends procps curl git python3-pip xz-utils \
-    && TARBALL="ffmpeg-git-amd64-static.tar.xz" \
+    && TARBALL="ffmpeg-master-latest-linux64-gpl.tar.xz" \
     && TMP_DIR=$(mktemp -d) \
-    && curl -sS -o "${TMP_DIR}/${TARBALL}" "https://johnvansickle.com/ffmpeg/builds/${TARBALL}" \
-    && curl -sS -o "${TMP_DIR}/${TARBALL}.md5" "https://johnvansickle.com/ffmpeg/builds/${TARBALL}.md5" \
-    && (cd "$TMP_DIR" && md5sum -c "${TARBALL}.md5") \
+    && curl -sS -L -o "${TMP_DIR}/${TARBALL}" "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/${TARBALL}" \
     && tar -xf "${TMP_DIR}/${TARBALL}" -C "$TMP_DIR" \
-    && EXTRACTED_DIR=$(find "$TMP_DIR" -maxdepth 1 -type d -name 'ffmpeg-*-static' | head -1) \
-    && install -m 755 "${EXTRACTED_DIR}/ffmpeg" /usr/local/bin/ffmpeg \
-    && install -m 755 "${EXTRACTED_DIR}/ffprobe" /usr/local/bin/ffprobe \
+    && EXTRACTED_DIR=$(find "$TMP_DIR" -maxdepth 1 -mindepth 1 -type d | head -1) \
+    && install -m 755 "${EXTRACTED_DIR}/bin/ffmpeg" /usr/local/bin/ffmpeg \
+    && install -m 755 "${EXTRACTED_DIR}/bin/ffprobe" /usr/local/bin/ffprobe \
     && rm -rf "$TMP_DIR" && \
     rm -rf /var/lib/apt/lists/* && \
     pip install --root-user-action=ignore --upgrade pip && \


### PR DESCRIPTION
## Summary

Switch the recorder image from John Van Sickle's FFmpeg static build to BtbN's FFmpeg-Builds `latest` Linux GPL archive.

## Changes

- replace the John Van Sickle download URL with BtbN's GitHub release URL
- remove checksum verification for the FFmpeg archive
- update extraction logic to install `ffmpeg` and `ffprobe` from the archive `bin/` directory

## Impact

This keeps the image behavior the same at a high level while changing the upstream source for FFmpeg binaries. The build now tracks BtbN's floating `latest` artifact instead of the previous source.