### PR TITLE
Update actions/checkout to v6

### DIFF
--- a/.github/workflows/build-contact-sheets.yml
+++ b/.github/workflows/build-contact-sheets.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to ghcr.io
         uses: docker/login-action@v3

--- a/.github/workflows/build-postproc-trigger.yml
+++ b/.github/workflows/build-postproc-trigger.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to ghcr.io
         uses: docker/login-action@v3

--- a/.github/workflows/build-streamlink.yml
+++ b/.github/workflows/build-streamlink.yml
@@ -16,7 +16,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to ghcr.io
         uses: docker/login-action@v3

--- a/.github/workflows/build-vcsi.yml
+++ b/.github/workflows/build-vcsi.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to ghcr.io
         uses: docker/login-action@v3


### PR DESCRIPTION
Bumps `actions/checkout` from `v4` to `v6` across all workflows to align with the latest stable release, providing improved security and Node.js 24 runtime compatibility.