### PR TITLE
Add chronological sequence suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,24 @@ A Docker-based system that automatically records [PaymoneyWubby](https://twitch.
 
 ## Overview
 
-When a stream goes live, the recording containers wake up and capture it. Once the stream ends, a post-processing pipeline runs automatically: contact sheet images are generated (grids of video thumbnails), a 4K poster image is created for each recording, and the files are renamed into episodic format (`S<YEAR>E<MONTH><DAY>`) so Jellyfin picks them up cleanly. The contact sheets are served via a Caddy web server for quick visual browsing.
+When a stream goes live, the recording containers wake up and capture it. Once the stream ends, a post-processing pipeline runs automatically: contact sheet images are generated (grids of video thumbnails), a 4K poster image is created for each recording, and the files are renamed into episodic format (`S<YEAR>E<MONTH><DAY><SEQ>`) so Jellyfin picks them up cleanly. The contact sheets are served via a Caddy web server for quick visual browsing.
+
+## Features
+
+- **Automated Recording:** Captures Kick and Twitch streams to `.mp4`.
+- **Contact Sheets:** Generates thumbnail grids for every recording.
+- **High-Res Posters:** Generates 4K (3840x2160) posters for Jellyfin.
+- **Auto-Renaming:** Moves completed files to a dynamic Season directory with episodic naming: `Wubby Streams - S2026E051101 - twitch-abc123de.mp4`.
+- **Web UI:** Browse contact sheets via a simple web interface.
+
+## Workflow
+
+1.  **Record:** Streamlink captures the raw stream.
+2.  **Post-Process (vcsi):**
+    -   Generates contact sheet in a separate web-root.
+    -   Generates a 16:9 poster image alongside the video.
+3.  **Rename + move to Jellyfin season directory (S<YEAR>E<MONTH><DAY><SEQ>)**
+4.  **Clean Up:** Stale contact sheets and orphaned images are pruned.
 
 ## How It Works
 
@@ -21,7 +38,7 @@ vcsi-trigger detects container exit
 vcsi pipeline runs:
   1. Generate contact sheet (3×5 thumbnail grid)
   2. Generate 4K poster image (3840×2160)
-  3. Rename + move to Jellyfin season directory (S<YEAR>E<MONTH><DAY>)
+  3. Rename + move to Jellyfin season directory (S<YEAR>E<MONTH><DAY><SEQ>)
   4. Rename contact sheets to match
   5. Clean up orphaned sheets/posters
       │
@@ -52,13 +69,13 @@ Recordings are organized as a TV show library:
 TV Shows/
 └── Wubby Streams/
     └── Season 2026/
-        ├── Wubby Streams - S2026E0511 - twitch-ab12cd34.mp4
-        ├── Wubby Streams - S2026E0511 - twitch-ab12cd34.jpg   ← poster
-        ├── Wubby Streams - S2026E0512 - kick-ef56gh78.mp4
-        └── Wubby Streams - S2026E0512 - kick-ef56gh78.jpg
+        ├── Wubby Streams - S2026E051101 - twitch-ab12cd34.mp4
+        ├── Wubby Streams - S2026E051101 - twitch-ab12cd34.jpg   ← poster
+        ├── Wubby Streams - S2026E051201 - kick-ef56gh78.mp4
+        └── Wubby Streams - S2026E051201 - kick-ef56gh78.jpg
 ```
 
-Poster images are 4K (3840×2160) so they look sharp at any display size. Episode numbers are derived from the current date (e.g., S2026E0511). Unique IDs at the end of filenames ensure no collisions if multiple streams occur on the same day.
+Poster images are 4K (3840×2160) so they look sharp at any display size. Episode numbers are derived from the file's modification date (e.g., S2026E051101). A two-digit sequence suffix is appended to handle multiple streams on the same day, ensuring correct chronological sorting in Jellyfin. Unique IDs at the end of filenames provide an extra layer of collision protection.
 
 ## Recording Details
 
@@ -145,3 +162,4 @@ Each recording container pings [Healthchecks.io](https://healthchecks.io) when a
     ├── Dockerfile              # vcsi image
     └── vcsi-run.sh             # Contact sheet + poster pipeline
 ```
+`

--- a/vcsi/vcsi-run.sh
+++ b/vcsi/vcsi-run.sh
@@ -147,13 +147,10 @@ done
 ###############################################################################
 mkdir -p "$SEASON_DIR"
 
-echo "[vcsi] $(date '+%F %T') moving completed VODs to $CURRENT_SEASON..."
+echo "[vcsi] $(date '+%F %T') moving completed VODs to Season folders..."
 
-# Format: Wubby Streams - S<YYYY>E<MMDD> - <base>
-SEASON_TAG="S$(date +%Y)"
-EPISODE_TAG="E$(date +%m%d)"
-
-# Move each completed mp4 (and its .jpg poster) from the input root to Season DIR
+# Move each completed mp4 (and its .jpg poster) from the input root to its respective Season DIR,
+# sorted by modification time so multiple new VODs are numbered chronologically.
 while IFS= read -r mp4; do
     [ -f "$mp4" ] || continue
     base=$(basename "$mp4" .mp4)
@@ -162,12 +159,27 @@ while IFS= read -r mp4; do
         echo "[vcsi] skipping ${base}.mp4 (recording still in progress)"
         continue
     fi
-    new_name="Wubby Streams - ${SEASON_TAG}${EPISODE_TAG} - ${base}"
-    mv -- "$mp4" "$SEASON_DIR/${new_name}.mp4"
+
+    # Derive date from the file itself to ensure correct chronological sorting
+    # and handle streams that cross midnight or are processed in batches.
+    fyear=$(date -r "$mp4" +%Y)
+    fdate=$(date -r "$mp4" +%m%d)
+    fseason_dir="$WUBBY_STREAMS_DIR/Season ${fyear}"
+    mkdir -p "$fseason_dir"
+
+    # Handle multiple streams on the same day by appending a sequence number.
+    # This ensures Jellyfin sorts them chronologically even if they share a date.
+    # We check the destination folder for existing .mp4 files with the same date tag.
+    count=$(find "$fseason_dir" -maxdepth 1 -name "Wubby Streams - S${fyear}E${fdate}*" -name "*.mp4" | wc -l)
+    seq_str=$(printf "%02d" $((count + 1)))
+    
+    new_name="Wubby Streams - S${fyear}E${fdate}${seq_str} - ${base}"
+
+    mv -- "$mp4" "$fseason_dir/${new_name}.mp4"
     echo "[vcsi] moved ${base}.mp4 -> ${new_name}.mp4"
     jpg="$TS_FOLDER/${base}.jpg"
     if [ -f "$jpg" ]; then
-        mv -- "$jpg" "$SEASON_DIR/${new_name}.jpg"
+        mv -- "$jpg" "$fseason_dir/${new_name}.jpg"
         echo "[vcsi] moved ${base}.jpg -> ${new_name}.jpg"
     fi
     sheet="$JPG_FOLDER/${base}.mp4.jpg"


### PR DESCRIPTION
## Summary
This PR fixes an issue where multiple VODs recorded on the same day (or batches containing streams that crossed midnight) were misordered in Jellyfin. By appending a sequence suffix to the episode tag, we ensure Jellyfin preserves the correct chronological order.

## Changes

### Post-Processing (vcsi/vcsi-run.sh)
 * Chronological Sequence Suffix: Updated the naming convention to S<YYYY>E<MMDD><SEQ> (e.g., S2026E051301, S2026E051302).
 * File-Derived Metadata: The script now uses each file's modification time (date -r) rather than the current system time to derive the year and date. This ensures accuracy for streams that start late and end early the following morning.
 * Dynamic Counting: Implemented a counter that checks the destination folder for existing recordings from the same day to automatically assign the next sequence number.
 * Robust Moving: Moved naming and directory creation logic inside the processing loop to handle multi-day batches correctly.

### Documentation (README.md)
 * Updated the Overview, Workflow, and Directory Structure sections to reflect the refined <SEQ> suffix.
 * Added clarification on how episode numbers are derived to ensure future maintainability.

### Impact
 * Jellyfin Sorting: Jellyfin now uses the unique episodic sequence number to sort files. This prevents the "alphabetical fallback" that caused misordering when multiple streams shared the same date tag.
 * Accuracy: Streams crossing midnight are now correctly tagged with the date they were actually recorded.