### PR TITLE
2-digit year format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ A Docker-based system that automatically records [PaymoneyWubby](https://twitch.
 
 ## Overview
 
-When a stream goes live, the recording containers wake up and capture it. Once the stream ends, a post-processing pipeline runs automatically: contact sheet images are generated (grids of video thumbnails), a 4K poster image is created for each recording, and the files are renamed into episodic format (`S<YEAR>E<MONTH><DAY><SEQ>`) so Jellyfin picks them up cleanly. The contact sheets are served via a Caddy web server for quick visual browsing.
+When a stream goes live, the recording containers wake up and capture it. Once the stream ends, a post-processing pipeline runs automatically: contact sheet images are generated (grids of video thumbnails), a 4K poster image is created for each recording, and the files are renamed into episodic format (`S<YY>E<MONTH><DAY><SEQ>`) so Jellyfin picks them up cleanly. The contact sheets are served via a Caddy web server for quick visual browsing.
 
 ## Features
 
 - **Automated Recording:** Captures Kick and Twitch streams to `.mp4`.
 - **Contact Sheets:** Generates thumbnail grids for every recording.
 - **High-Res Posters:** Generates 4K (3840x2160) posters for Jellyfin.
-- **Auto-Renaming:** Moves completed files to a dynamic Season directory with episodic naming: `Wubby Streams - S2026E051101 - twitch-abc123de.mp4`.
+- **Auto-Renaming:** Moves completed files to a dynamic Season directory with episodic naming: `Wubby Streams - S26E051101 - twitch-abc123de.mp4`.
 - **Web UI:** Browse contact sheets via a simple web interface.
 
 ## Workflow
@@ -20,7 +20,7 @@ When a stream goes live, the recording containers wake up and capture it. Once t
 2.  **Post-Process (vcsi):**
     -   Generates contact sheet in a separate web-root.
     -   Generates a 16:9 poster image alongside the video.
-3.  **Rename + move to Jellyfin season directory (S<YEAR>E<MONTH><DAY><SEQ>)**
+3.  **Rename + move to Jellyfin season directory (S<YY>E<MONTH><DAY><SEQ>)**
 4.  **Clean Up:** Stale contact sheets and orphaned images are pruned.
 
 ## How It Works
@@ -38,7 +38,7 @@ vcsi-trigger detects container exit
 vcsi pipeline runs:
   1. Generate contact sheet (3×5 thumbnail grid)
   2. Generate 4K poster image (3840×2160)
-  3. Rename + move to Jellyfin season directory (S<YEAR>E<MONTH><DAY><SEQ>)
+  3. Rename + move to Jellyfin season directory (S<YY>E<MONTH><DAY><SEQ>)
   4. Rename contact sheets to match
   5. Clean up orphaned sheets/posters
       │
@@ -68,14 +68,14 @@ Recordings are organized as a TV show library:
 ```
 TV Shows/
 └── Wubby Streams/
-    └── Season 2026/
-        ├── Wubby Streams - S2026E051101 - twitch-ab12cd34.mp4
-        ├── Wubby Streams - S2026E051101 - twitch-ab12cd34.jpg   ← poster
-        ├── Wubby Streams - S2026E051201 - kick-ef56gh78.mp4
-        └── Wubby Streams - S2026E051201 - kick-ef56gh78.jpg
+    └── Season 26/
+        ├── Wubby Streams - S26E051101 - twitch-ab12cd34.mp4
+        ├── Wubby Streams - S26E051101 - twitch-ab12cd34.jpg   ← poster
+        ├── Wubby Streams - S26E051201 - kick-ef56gh78.mp4
+        └── Wubby Streams - S26E051201 - kick-ef56gh78.jpg
 ```
 
-Poster images are 4K (3840×2160) so they look sharp at any display size. Episode numbers are derived from the file's modification date (e.g., S2026E051101). A two-digit sequence suffix is appended to handle multiple streams on the same day, ensuring correct chronological sorting in Jellyfin. Unique IDs at the end of filenames provide an extra layer of collision protection.
+Poster images are 4K (3840×2160) so they look sharp at any display size. Episode numbers are derived from the file's modification date (e.g., S26E051101). A two-digit sequence suffix is appended to handle multiple streams on the same day, ensuring correct chronological sorting in Jellyfin. Unique IDs at the end of filenames provide an extra layer of collision protection.
 
 ## Recording Details
 

--- a/vcsi/vcsi-run.sh
+++ b/vcsi/vcsi-run.sh
@@ -5,7 +5,7 @@ TS_FOLDER="${TS_FOLDER:-/input}"
 JPG_FOLDER="${JPG_FOLDER:-/output}"
 FONT_PATH="${FONT_PATH:-/usr/share/fonts/truetype/Misc-Fixed-7x13.ttf}"
 WUBBY_STREAMS_DIR="$TS_FOLDER/TV Shows/Wubby Streams"
-CURRENT_SEASON="Season $(date +%Y)"
+CURRENT_SEASON="Season $(date +%y)"
 SEASON_DIR="$WUBBY_STREAMS_DIR/$CURRENT_SEASON"
 
 RESCAN=false
@@ -162,7 +162,7 @@ while IFS= read -r mp4; do
 
     # Derive date from the file itself to ensure correct chronological sorting
     # and handle streams that cross midnight or are processed in batches.
-    fyear=$(date -r "$mp4" +%Y)
+    fyear=$(date -r "$mp4" +%y)
     fdate=$(date -r "$mp4" +%m%d)
     fseason_dir="$WUBBY_STREAMS_DIR/Season ${fyear}"
     mkdir -p "$fseason_dir"


### PR DESCRIPTION
## Summary
This PR refines the episodic naming convention and directory structure by transitioning from a 4-digit year format to a more compact 2-digit format for better visual consistency.

## Changes

### Post-Processing (vcsi/vcsi-run.sh)
 * Two-Digit Year Format: Updated the `CURRENT_SEASON` and episode tag generation to use the last two digits of the year (e.g., Season 26 and S26E...).
 * Synchronization: Ensured both the static initialization and the dynamic per-file logic use the same %y format.

### Documentation (README.md)
 * Updated all directory structure diagrams to use the Season 26 naming style.
 * Updated naming examples and placeholders to reflect the refined `S26E<MMDD><SEQ>` format.

### Impact
 * Brief Filenames: Filenames and folders are now more concise while maintaining full compatibility with Jellyfin's episodic matching.
 * Example Result: `Wubby Streams - S26E051501 - kick-8e10c5fe.mp4`