### PR TITLE
Make vcsi persistent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,13 +93,14 @@ services:
       context: ./vcsi
       dockerfile: Dockerfile
     container_name: vcsi
+    command: ["--stay-alive"]
     environment:
       - TZ=Europe/Budapest
     user: "1000:1000"
     volumes:
       - ${VOD_DIR}:/input
       - ${CONTACT_SHEETS_DIR}:/output
-    restart: "no"
+    restart: unless-stopped
     logging:
       driver: "json-file"
       options:

--- a/manual-vcsi.sh
+++ b/manual-vcsi.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-docker rm vcsi-manual 2>/dev/null || true
-docker compose -f ~/docker/streamlink/docker-compose.yml run --name vcsi-manual vcsi --rescan
+docker exec vcsi /usr/local/bin/vcsi-run.sh --rescan

--- a/postproc-trigger/watch-postproc.sh
+++ b/postproc-trigger/watch-postproc.sh
@@ -22,13 +22,7 @@ while read action cname; do
           ;;
         die)
           echo "[watch-postproc] $(date '+%F %T')  $cname ended - running vcsi"
-          docker rm vcsi-runner 2>/dev/null || true
-          docker run \
-            --name vcsi-runner \
-            --user "1000:1000" \
-            -v "${VOD_DIR:?VOD_DIR env var required}:/input" \
-            -v "${CONTACT_SHEETS_DIR:?CONTACT_SHEETS_DIR env var required}:/output" \
-            ghcr.io/56k-modem/vcsi:latest
+          docker exec vcsi /usr/local/bin/vcsi-run.sh
           echo "[watch-postproc] $(date '+%F %T') vcsi finished"
           ;;
       esac

--- a/vcsi/vcsi-run.sh
+++ b/vcsi/vcsi-run.sh
@@ -9,8 +9,10 @@ CURRENT_SEASON="Season $(date +%y)"
 SEASON_DIR="$WUBBY_STREAMS_DIR/$CURRENT_SEASON"
 
 RESCAN=false
+STAY_ALIVE=false
 for arg in "$@"; do
     [[ "$arg" == "--rescan" ]] && RESCAN=true
+    [[ "$arg" == "--stay-alive" ]] && STAY_ALIVE=true
 done
 
 echo "[vcsi] $(date '+%F %T')  pass started"
@@ -192,3 +194,8 @@ done < <(find "$TS_FOLDER" -maxdepth 1 -name "*.mp4" -printf '%T@ %p\n' | sort -
 echo "[vcsi] $(date '+%F %T') VOD move finished"
 
 echo "[vcsi] $(date '+%F %T')  pass finished"
+
+if $STAY_ALIVE; then
+    echo "[vcsi] Entering stay-alive mode..."
+    exec sleep infinity
+fi


### PR DESCRIPTION
## Summary
This PR transitions the vcsi service from a transient, one-off container to a persistent "daemon" container. This ensures the vcsi image is always recognized as "in use" by Docker, preventing it from being removed during `docker image prune -a` operations.

## Changes
 - `vcsi/vcsi-run.sh`: Added a `--stay-alive` flag that invokes sleep infinity after the processing logic completes.
 - `docker-compose.yml`:
   - Updated vcsi service with command: `["--stay-alive"]`.
   - Changed restart policy to `unless-stopped`.
 - `postproc-trigger/watch-postproc.sh`: Refactored to use `docker exec` instead of `docker run`, allowing it to trigger the processing logic inside the existing persistent container.
 - `manual-vcsi.sh`: Updated to use `docker exec` for manual rescans.

## Impact
 - Image Persistence: The vcsi image is no longer flagged as unused by Docker.
 - Performance: Using docker exec avoids the overhead of creating a new container (filesystem layers, volume mounts) every time a stream ends.
 - Cleanliness: Removes the need to manually `docker rm` temporary runner containers.